### PR TITLE
Update master

### DIFF
--- a/pl-PL/apps/blog/language/pl-PL/pl-PL.com_zoo.ini
+++ b/pl-PL/apps/blog/language/pl-PL/pl-PL.com_zoo.ini
@@ -4,9 +4,19 @@
 
 ; Blog App
 
-RELATED ARTICLES="Powiązane artykuły"
-ARTICLES TAGGED WITH="Artykuły z tagami"
+RELATED ARTICLES="Artykuły powiązane"
+ARTICLES TAGGED WITH="Artykuły ze słowami kluczowymi (tagami)"
+ARTICLES IN CATEGORY="Artykuły w kategorii"
+;GUEST="Gość"
+;HI %S, HERE YOU CAN EDIT YOUR SUBMISSIONS AND ADD NEW SUBMISSION.="Witaj %s, tutaj możesz dodawać i edytować swoje wpisy."
+FIRST="Pierwszy"
+LAST="Ostatni"
+ADMINISTRATION="Administrowanie" 
+MEDIA="Media"
+;META="Metadane"
+;EDIT %S="Edytuj %s" 
+;ADD %S="Dodaj %s" 
 
 ; Core Item Link
 
-READ_MORE="Cztaj dalej"
+;READ_MORE="Czytaj dalej"


### PR DESCRIPTION
I added all JText phrases from Blog application. Some are not inserted in Blog app com_zoo.ini, and in global /language/en-GB.com_zoo.ini.
Example: phrase ARTICLES IN CATEGORY="Articles in Category" in category.php

Some texts are redundant, they are in global /language/en-GB.com_zoo.ini. but the are in Blog app. I inserted them commented. Please fell free to remove them or uncomment it.
